### PR TITLE
Clear out pre-activated-features config in FeatureActivationTestSuite

### DIFF
--- a/node-it/src/test/scala/com/wavesplatform/it/sync/activation/FeatureActivationTestSuite.scala
+++ b/node-it/src/test/scala/com/wavesplatform/it/sync/activation/FeatureActivationTestSuite.scala
@@ -25,7 +25,7 @@ class FeatureActivationTestSuite
     NodeConfigs.newBuilder
       .overrideBase(_.raw(s"""TN {
                                |  blockchain.custom.functionality {
-                               |    pre-activated-features = {}
+                               |    pre-activated-features = null
                                |    feature-check-blocks-period = $votingInterval
                                |    blocks-for-feature-activation = $blocksForActivation
                                |  }


### PR DESCRIPTION
With HOCON you can't overwrite an object with `{}` because by default two objects are merged. Your test was picking up feature 1 as a pre activated feature because of this line that was added to your top level application.conf:

https://github.com/BlackTurtle123/TurtleNetwork/blob/v1.0.0/node/src/main/resources/application.conf#L34

The Waves project makes the same mistake in the test file but their application.conf is different so it doesn't cause the test to fail.