### PR TITLE
Fix DataTransactionBodyBytesByteVectorSuite

### DIFF
--- a/node-it/src/test/scala/com/wavesplatform/it/sync/smartcontract/DataTransactionBodyBytesByteVectorSuite.scala
+++ b/node-it/src/test/scala/com/wavesplatform/it/sync/smartcontract/DataTransactionBodyBytesByteVectorSuite.scala
@@ -75,7 +75,7 @@ class DataTransactionBodyBytesByteVectorSuite extends BaseTransactionSuite {
     )
 
   private val maxDataEntriesV2 =
-    maxDataEntriesV1 :+ BinaryDataEntry("f", ByteStr.fill(12378)(1))
+    maxDataEntriesV1 :+ BinaryDataEntry("f", ByteStr.fill(12377)(1))
 
   test("filled data transaction body bytes") {
     checkByteVectorLimit(firstKeyPair, maxDataEntriesV1, scriptV3, TxVersion.V1)
@@ -93,7 +93,7 @@ class DataTransactionBodyBytesByteVectorSuite extends BaseTransactionSuite {
 
     sender.putData(address, data, version = version, fee = calcDataFee(data, version) + smartFee, waitForTx = true).id
 
-    val increasedData = data.head.copy(value = data.head.value ++ ByteStr.fromBytes(1)) :: data.tail
+    val increasedData = data.head.copy(value = data.head.value ++ ByteStr.fromBytes(1) ++ ByteStr.fromBytes(1)) :: data.tail
     assertBadRequestAndMessage(
       sender.putData(address, increasedData, version = version, fee = calcDataFee(data, version) + smartFee),
       "Too big sequences requested"


### PR DESCRIPTION
The bug happens because TN fee for the datatx is 330000000 instead of 16700000 which adds a byte.

In this case I have removed a byte from the evaluated data-tx however length validation of the ProtoDataPayload does not seem to be in respect to fees
 
![image](https://user-images.githubusercontent.com/36687889/95002586-c6271880-05e6-11eb-9c82-574a97a9189f.png)

In the TN implementation, data transaction are the same length as in Waves however the actual data entries is 1 byte less. No idea how this will impact us going forwards if any. 

Terms.DataTxMaxProtoBytes should be based on DataTransaction.MaxProtoBytes but MaxProtoBytes might be a calculation already made relative fees and so we might need to reduce it by 1 or risk transactions being 1 byte longer then expected.