### PR TITLE
Fix test BlockWithMaxBaseTargetTest

### DIFF
--- a/node/src/test/scala/com/wavesplatform/mining/BlockWithMaxBaseTargetTest.scala
+++ b/node/src/test/scala/com/wavesplatform/mining/BlockWithMaxBaseTargetTest.scala
@@ -120,7 +120,8 @@ class BlockWithMaxBaseTargetTest extends FreeSpec with Matchers with WithDB with
     val minerSettings = settings0.minerSettings.copy(quorum = 0)
     val blockchainSettings0 = settings0.blockchainSettings.copy(
       functionalitySettings = settings0.blockchainSettings.functionalitySettings.copy(
-        preActivatedFeatures = Map(BlockchainFeatures.FairPoS.id -> 1)
+        preActivatedFeatures = Map(BlockchainFeatures.FairPoS.id -> 1),
+        blockVersion3AfterHeight = 1
       )
     )
     val synchronizationSettings0 = settings0.synchronizationSettings.copy(maxBaseTargetOpt = Some(1L))


### PR DESCRIPTION
Issue happens because the TN network applies v3 blocks at position 0 instead of 161700 (Waves Testnet CONF). 

The tested block is v2 at position 2 (0+1 < 2 = true therefore block must equal to v3) which throws a error and returns error code 0.

![image](https://user-images.githubusercontent.com/36687889/95015950-f9a68900-0660-11eb-8698-24e7641397a3.png)

This fix sets the locally tested blockchain setting to apply v3 at 1 which will evaluate
1+1 < 2 = false